### PR TITLE
fixed ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
     branches: [ main ]
 
@@ -16,8 +16,9 @@ jobs:
       - name: Set up Elixir/OTP
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.13"
-          otp-version: "24.0"
+          elixir-version: "1.18.3"
+          otp-version: "27.0"
+          version-type: "loose" 
 
       - name: Install Dependencies
         run: mix deps.get


### PR DESCRIPTION
This pull request updates the CI workflow configuration to expand branch coverage and upgrade the Elixir/OTP versions used in the pipeline.

### CI Workflow Updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL5-R5): Updated the `push` event to trigger on both `main` and `dev` branches, expanding the scope of CI checks.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL19-R21): Upgraded Elixir to version `1.18.3` and OTP to version `27.0` in the CI job setup, ensuring compatibility with newer versions. Added `version-type: "loose"` for more flexible version resolution.